### PR TITLE
allowJs to true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "lib": ["es2015", "dom"],
+    "allowJs": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Required configuration to Jest 28
Warning error below

```
Got a `.js` file to compile while `allowJs` option is not set to `true`
```
